### PR TITLE
Fix iOS Safari cutting notifications when navbar is visible

### DIFF
--- a/test/vaadin-notification-test.html
+++ b/test/vaadin-notification-test.html
@@ -56,6 +56,18 @@
           var isVisible = (elem) => !!(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length);
           expect(isVisible(document.body.querySelector('vaadin-notification-overlay'))).to.be.true;
         });
+
+        // iOS Safari has incorrect viewport height when navigation bar is
+        // visible in landscape orientation. This is workarounded by exposing
+        // --vaadin-overlay-viewport-bottom in <vaadin-overlay>.
+        if (!window.ShadyCSS || window.ShadyCSS.nativeCss) {
+          it('should support --vaadin-overlay-viewport-bottom CSS property', () => {
+            const overlay = notification.constructor._overlay;
+            overlay.style.setProperty('--vaadin-overlay-viewport-bottom', '50px');
+            const content = overlay.shadowRoot.querySelector('[part="content"]');
+            expect(getComputedStyle(content).getPropertyValue('bottom')).to.equal('50px');
+          });
+        }
       });
 
       describe('a11y', () => {

--- a/vaadin-notification.html
+++ b/vaadin-notification.html
@@ -36,10 +36,9 @@ This program is available under Apache License Version 2.0, available at https:/
         position: fixed;
         top: 0;
         left: 0;
-        width: 100vw;
-        height: 100vh;
+        bottom: var(--vaadin-overlay-viewport-bottom, 0);
+        right: 0;
         box-sizing: border-box;
-        overflow: auto;
 
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
Fixes #19

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-notification/23)
<!-- Reviewable:end -->
