### PR TITLE
Update default Lumo theme

### DIFF
--- a/demo/notification-basic-demos.html
+++ b/demo/notification-basic-demos.html
@@ -11,8 +11,10 @@
       <template preserve-content>
         <vaadin-notification opened duration="4000">
           <template>
-            <b>Notice</b><br>
-            This notification has HTML content
+            <div>
+              <b>Notice</b><br>
+              This notification has HTML content
+            </div>
           </template>
         </vaadin-notification>
       </template>
@@ -54,7 +56,6 @@
             <vaadin-notification id="noti-elm" duration="0" position="bottom-end">
               <template>
                 This notification remains opened until the button inside is clicked.
-                <br/>
                 <vaadin-button on-click="_close">Close</vaadin-button>
               </template>
             </vaadin-notification>
@@ -82,7 +83,7 @@
         <script>
           window.showNotification = function() {
             const template = document.createElement('template');
-            template.innerHTML = '<b>Alert</b><br>This is a dynamic notification created with JavaScript';
+            template.innerHTML = '<div><b>Alert</b><br>This is a dynamic notification created with JavaScript</div>';
 
             const notify = document.createElement('vaadin-notification');
             notify.position = 'middle';

--- a/theme/lumo/vaadin-notification.html
+++ b/theme/lumo/vaadin-notification.html
@@ -12,14 +12,13 @@
       }
 
       [part="overlay"] {
-        background-color: var(--lumo-shade-90pct);
+        background: var(--lumo-base-color) linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
         border-radius: var(--lumo-border-radius);
-        box-shadow: var(--lumo-box-shadow-l);
-        color: var(--lumo-tint-90pct);
+        box-shadow: 0 0 0 1px var(--lumo-contrast-10pct), var(--lumo-box-shadow-l);
         font-family: var(--lumo-font-family);
         font-size: var(--lumo-font-size-m);
         font-weight: 400;
-        line-height: var(--lumo-line-height-m);
+        line-height: var(--lumo-line-height-s);
         letter-spacing: 0;
         text-transform: none;
         -webkit-text-size-adjust: 100%;
@@ -30,6 +29,14 @@
 
       [part="content"] {
         padding: var(--lumo-space-wide-l);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      [part="content"] ::slotted(vaadin-button) {
+        flex: none;
+        margin: 0 calc(var(--lumo-space-s) * -1) 0 var(--lumo-space-s);
       }
 
       :host([slot^="middle"]) {

--- a/theme/lumo/vaadin-notification.html
+++ b/theme/lumo/vaadin-notification.html
@@ -24,7 +24,6 @@
         -webkit-text-size-adjust: 100%;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
-        -webkit-backdrop-filter: blur(2px);
       }
 
       [part="content"] {
@@ -36,7 +35,7 @@
 
       [part="content"] ::slotted(vaadin-button) {
         flex: none;
-        margin: 0 calc(var(--lumo-space-s) * -1) 0 var(--lumo-space-s);
+        margin: 0 calc(var(--lumo-space-s) * -1) 0 var(--lumo-space-m);
       }
 
       :host([slot^="middle"]) {

--- a/theme/lumo/vaadin-notification.html
+++ b/theme/lumo/vaadin-notification.html
@@ -3,22 +3,33 @@
 <link rel="import" href="../../../vaadin-lumo-styles/style.html">
 <link rel="import" href="../../../vaadin-lumo-styles/typography.html">
 
-<link rel="import" href="../../../vaadin-lumo-styles/mixins/overlay.html">
-
 <dom-module id="lumo-notification-card" theme-for="vaadin-notification-card">
   <template>
-    <style include="lumo-overlay">
+    <style>
       :host {
         position: relative;
         margin: var(--lumo-space-s);
       }
 
       [part="overlay"] {
-        background-image: linear-gradient(var(--lumo-contrast-5pct), var(--lumo-contrast-5pct));
+        background-color: var(--lumo-shade-90pct);
+        border-radius: var(--lumo-border-radius);
+        box-shadow: var(--lumo-box-shadow-l);
+        color: var(--lumo-tint-90pct);
+        font-family: var(--lumo-font-family);
+        font-size: var(--lumo-font-size-m);
+        font-weight: 400;
+        line-height: var(--lumo-line-height-m);
+        letter-spacing: 0;
+        text-transform: none;
+        -webkit-text-size-adjust: 100%;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-backdrop-filter: blur(2px);
       }
 
       [part="content"] {
-        padding: var(--lumo-space-wide-m);
+        padding: var(--lumo-space-wide-l);
       }
 
       :host([slot^="middle"]) {

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -3,7 +3,7 @@ var argv = require('yargs').argv;
 module.exports = {
   registerHooks: function(context) {
     var saucelabsPlatforms = [
-      'macOS 10.12/iphone@10.3',
+      'macOS 10.12/iphone@11.0',
       'macOS 10.12/ipad@10.3',
       'Windows 10/microsoftedge@15',
       'Windows 10/internet explorer@11',


### PR DESCRIPTION
Don’t use the `lumo-overlay` mixin, as notifications are more of a special case, and not that much like the other overlay elements.

Use a dark background color for both light and dark palette. This makes the notifications more prominent for the light theme, and easier to notice by the end user.

Increase content padding.

This is a sort of a breaking change, that the visuals change quite drastically – but, it doesn’t actually break anything and can be considered as an enhancement. Since this is highly subjective, I’m asking for feedback through a pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-notification/51)
<!-- Reviewable:end -->
