### PR TITLE
Reorganize demos

### DIFF
--- a/demo/demos.json
+++ b/demo/demos.json
@@ -1,26 +1,37 @@
 {
   "name": "Vaadin Notification",
   "pages": [
-  {
-    "name": "Basics",
-    "url": "notification-basic-demos",
-    "src": "notification-basic-demos.html",
-    "meta": {
-      "title": "Vaadin Notification Basic Examples",
-      "description": "",
-      "image": ""
-     }
-  }
-  ,
-  {
-    "name": "Advanced Usage",
-    "url": "notification-advanced-demos",
-    "src": "notification-advanced-demos.html",
-    "meta": {
-      "title": "Vaadin Notification Advanced Examples",
-      "description": "",
-      "image": ""
-     }
-  }
+    {
+      "name": "Basics",
+      "url": "notification-basic-demos",
+      "src": "notification-basic-demos.html",
+      "meta": {
+        "title": "Vaadin Notification Basic Examples",
+        "description": "",
+        "image": ""
+      }
+    }
+    ,
+    {
+      "name": "Styling",
+      "url": "notification-styling-demos",
+      "src": "notification-styling-demos.html",
+      "meta": {
+        "title": "Vaadin Notification Styling Examples",
+        "description": "",
+        "image": ""
+      }
+    }
+    ,
+    {
+      "name": "Sampler",
+      "url": "notification-sampler-demos",
+      "src": "notification-sampler-demos.html",
+      "meta": {
+        "title": "Vaadin Notification Sampler",
+        "description": "",
+        "image": ""
+      }
+    }
   ]
 }

--- a/demo/notification-basic-demos.html
+++ b/demo/notification-basic-demos.html
@@ -12,7 +12,7 @@
         <dom-bind id="bind-elm">
           <template>
             <vaadin-button on-click="_openNotification">Open notification</vaadin-button>
-            <vaadin-notification duration="4000" id="notification">
+            <vaadin-notification duration="0" id="notification">
               <template>
                 <div>
                   <b>Notice</b><br>
@@ -59,32 +59,17 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Binding the `opened` property</h3>
-    <vaadin-demo-snippet id="notification-basic-demos-binding">
-      <template preserve-content>
-        <dom-bind>
-          <template>
-            <vaadin-checkbox checked="{{notificationOpened}}">Show notification</vaadin-checkbox>
-            <vaadin-notification opened="{{notificationOpened}}">
-              <template>
-                The checkbox stays checked the time this notification is shown
-              </template>
-            </vaadin-notification>
-          </template>
-        </dom-bind>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h3>Interacting with Content</h3>
+    <h3>Action</h3>
+    <p>Use a text button to allow users take action on a process performed by the app.</p>
     <vaadin-demo-snippet id="notification-basic-demos-interaction">
       <template preserve-content>
         <dom-bind id="bind-elm">
           <template>
             <vaadin-button on-click="_open">Open Notification</button>
-            <vaadin-notification id="noti-elm" duration="0" position="bottom-end">
+            <vaadin-notification id="noti-elm">
               <template>
-                This notification remains opened until the button inside is clicked.
-                <vaadin-button on-click="_close">Close</vaadin-button>
+                Can't send message.
+                <vaadin-button on-click="_close" theme="tertiary">Retry</vaadin-button>
               </template>
             </vaadin-notification>
           </template>
@@ -104,55 +89,6 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Styling the Content</h3>
-    <vaadin-demo-snippet id="notification-basic-global-scope-styling">
-      <template preserve-content>
-        <dom-bind>
-          <template>
-            <style>
-              .notification {
-                font: italic 24pt serif;
-                background: #fff;
-                color: #000;
-                padding: 1em;
-                border: .25em solid #000;
-              }
-            </style>
-            <vaadin-checkbox checked="{{notificationOpened}}">Show notification</vaadin-checkbox>
-            <vaadin-notification opened="{{notificationOpened}}">
-              <template>
-                <div class="notification">
-                  I am styled with notification class.
-                </div>
-              </template>
-            </vaadin-notification>
-          </template>
-        </dom-bind>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h3>Using from JavaScript</h3>
-    <vaadin-demo-snippet id="notification-basic-demos-using-from-js">
-      <template preserve-content>
-        <vaadin-button onclick="showNotification()">Trigger the dynamic notification</vaadin-button>
-        <script>
-          window.showNotification = function() {
-            const template = document.createElement('template');
-            template.innerHTML = '<div><b>Alert</b><br>This is a dynamic notification created with JavaScript</div>';
-
-            const notify = document.createElement('vaadin-notification');
-            notify.position = 'middle';
-            notify.appendChild(template);
-
-            document.body.appendChild(notify);
-            notify.open();
-            notify.addEventListener('opened-changed', function() {
-              document.body.removeChild(notify);
-            });
-          };
-        </script>
-      </template>
-    </vaadin-demo-snippet>
   </template>
   <script>
     class NotificationBasicDemos extends DemoReadyEventEmitter(NotificationDemo(Polymer.Element)) {

--- a/demo/notification-sampler-demos.html
+++ b/demo/notification-sampler-demos.html
@@ -1,4 +1,4 @@
-<dom-module id="notification-advanced-demos">
+<dom-module id="notification-sampler-demos">
   <template>
     <style include="vaadin-component-demo-shared-styles">
       :host {
@@ -7,7 +7,7 @@
     </style>
 
     <h3>Notification Sampler</h3>
-    <vaadin-demo-snippet id="notification-advanced-demos-custom">
+    <vaadin-demo-snippet id="notification-sampler-demos-custom">
       <template preserve-content>
         <dom-module id="notification-full-demo">
           <template preserve-content>
@@ -44,15 +44,15 @@
                   <vaadin-radio-button name="radio-group" value="bottom-stretch">bottom-stretch</vaadin-radio-button>
                 </vaadin-radio-group>
               </div>
-              <vaadin-text-field label="Duration" value="{{duration}}" pattern="\d\d*" style="width: 100px">
+              <vaadin-text-field label="Duration" value="{{duration}}" pattern="\d\d*" style="width: 100px;">
                 <span slot="suffix">ms</span>
               </vaadin-text-field>
-              <vaadin-text-field label="Text" value="{{text}}" flex="1" style="width: 300px"></vaadin-text-field>
+              <vaadin-text-field label="Text" value="{{text}}" flex="1" style="width: 300px;"></vaadin-text-field>
               <vaadin-button on-click="_show">Show Notification</vaadin-button>
             </div>
           </template>
           <script>
-          window.addDemoReadyListener('#notification-advanced-demos-custom', function(document) {
+          window.addDemoReadyListener('#notification-sampler-demos-custom', function(document) {
             Polymer({
               is: 'notification-full-demo',
 
@@ -103,11 +103,11 @@
 
 
   <script>
-    class NotificationAdvancedDemos extends DemoReadyEventEmitter(NotificationDemo(Polymer.Element)) {
+    class NotificationSamplerDemos extends DemoReadyEventEmitter(NotificationDemo(Polymer.Element)) {
       static get is() {
-        return 'notification-advanced-demos';
+        return 'notification-sampler-demos';
       }
     }
-    customElements.define(NotificationAdvancedDemos.is, NotificationAdvancedDemos);
+    customElements.define(NotificationSamplerDemos.is, NotificationSamplerDemos);
   </script>
 </dom-module>

--- a/demo/notification-styling-demos.html
+++ b/demo/notification-styling-demos.html
@@ -1,0 +1,45 @@
+<dom-module id="notification-styling-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+    <h3>Styling the Content</h3>
+    <vaadin-demo-snippet id="notification-basic-global-scope-styling">
+      <template preserve-content>
+        <dom-bind>
+          <template>
+            <style>
+              .notification {
+                font: italic 24pt serif;
+                background: #fff;
+                color: #000;
+                padding: 1em;
+                border: .25em solid #000;
+              }
+            </style>
+            <vaadin-checkbox checked="{{notificationOpened}}">Show notification</vaadin-checkbox>
+            <vaadin-notification opened="{{notificationOpened}}" duration="0">
+              <template>
+                <div class="notification">
+                  I am styled with notification class.
+                </div>
+              </template>
+            </vaadin-notification>
+          </template>
+        </dom-bind>
+      </template>
+    </vaadin-demo-snippet>
+    
+  </template>
+  <script>
+    class NotificationStylingDemos extends DemoReadyEventEmitter(NotificationDemo(Polymer.Element)) {
+      static get is() {
+        return 'notification-styling-demos';
+      }
+    }
+    customElements.define(NotificationStylingDemos.is, NotificationStylingDemos);
+  </script>
+</dom-module>


### PR DESCRIPTION
Connects to "Guidelines for component examples"

- Created Styling page with the styling example
- Changed `Interacting with Content` into `Action` with description and real-life example
- Renamed advanced to Sampler and moved the sampler demo there.
- Removed demos that are duplicates of API and don't show real-life usage: "Binding the `opened` property" and "Using from JavaScript"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-notification/75)
<!-- Reviewable:end -->
