### PR TITLE
feat: prepare for TS defs generation

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,10 +1,10 @@
-import { NotificationCard, NotificationElement } from '../src/vaadin-notification.js';
+import { NotificationElement } from '../src/vaadin-notification.js';
 
 export type NotificationPosition =
   'top-stretch' | 'top-start' | 'top-center' | 'top-end' | 'middle' | 'bottom-start' | 'bottom-center' | 'bottom-end' |
   'bottom-stretch';
 
 export type NotificationRenderer = (
-  root: NotificationCard,
+  root: HTMLElement,
   notification: NotificationElement
 ) => void;

--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,0 +1,10 @@
+import { NotificationCard, NotificationElement } from '../src/vaadin-notification.js';
+
+export type NotificationPosition =
+  'top-stretch' | 'top-start' | 'top-center' | 'top-end' | 'middle' | 'bottom-start' | 'bottom-center' | 'bottom-end' |
+  'bottom-stretch';
+
+export type NotificationRenderer = (
+  root: NotificationCard,
+  notification: NotificationElement
+) => void;

--- a/bower.json
+++ b/bower.json
@@ -26,8 +26,8 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.3.2",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.0",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.2"
   },

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,15 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ],
+  "autoImport": {
+    "./@types/interfaces": [
+      "NotificationPosition",
+      "NotificationRenderer"
+    ]
+  }
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,11 @@
+module.exports = {
+  files: [
+    'vaadin-notification.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
+    "@types",
     "src",
     "theme"
   ],

--- a/src/vaadin-notification.html
+++ b/src/vaadin-notification.html
@@ -116,6 +116,8 @@ This program is available under Apache License Version 2.0, available at https:/
        * The container element for all notifications.
        *
        * @memberof Vaadin
+       * @mixes Vaadin.ElementMixin
+       * @mixes Vaadin.ThemableMixin
        */
       class NotificationContainer extends Vaadin.ThemableMixin(Vaadin.ElementMixin(Polymer.Element)) {
         static get is() {
@@ -126,6 +128,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return {
             /**
              * True when the container is opened
+             * @type {boolean}
              */
             opened: {
               type: Boolean,
@@ -135,6 +138,7 @@ This program is available under Apache License Version 2.0, available at https:/
           };
         }
 
+        /** @private */
         _openedChanged(opened) {
           if (opened) {
             document.body.appendChild(this);
@@ -158,6 +162,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _detectIosNavbar() {
           const innerHeight = window.innerHeight;
           const innerWidth = window.innerWidth;
@@ -193,6 +198,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return 'vaadin-notification-card';
         }
 
+        /** @protected */
         ready() {
           super.ready();
           this.setAttribute('role', 'alert');
@@ -256,6 +262,7 @@ This program is available under Apache License Version 2.0, available at https:/
        *
        * @memberof Vaadin
        * @mixes Vaadin.ThemePropertyMixin
+       * @mixes Vaadin.ElementMixin
        * @demo demo/index.html
        */
       class NotificationElement extends Vaadin.ThemePropertyMixin(Vaadin.ElementMixin(Polymer.Element)) {
@@ -272,6 +279,7 @@ This program is available under Apache License Version 2.0, available at https:/
             /**
              * The duration in milliseconds to show the notification.
              * Set to `0` or a negative number to disable the notification auto-closing.
+             * @type {number}
              */
             duration: {
               type: Number,
@@ -280,6 +288,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * True if the notification is currently displayed.
+             * @type {boolean}
              */
             opened: {
               type: Boolean,
@@ -291,6 +300,7 @@ This program is available under Apache License Version 2.0, available at https:/
             /**
              * Alignment of the notification in the viewport
              * Valid values are `top-stretch|top-start|top-center|top-end|middle|bottom-start|bottom-center|bottom-end|bottom-stretch`
+             * @type {!NotificationPosition}
              */
             position: {
               type: String,
@@ -305,11 +315,14 @@ This program is available under Apache License Version 2.0, available at https:/
              * - `root` The `<vaadin-notification-card>` DOM element. Append
              *   your content to it.
              * - `notification` The reference to the `<vaadin-notification>` element.
+             * @type {!NotificationRenderer | undefined}
              */
             renderer: Function,
 
             /**
              * The template of the notification card content.
+             * @type {!HTMLTemplateElement | undefined}
+             * @protected
              */
             _notificationTemplate: Object
           };
@@ -322,6 +335,7 @@ This program is available under Apache License Version 2.0, available at https:/
           ];
         }
 
+        /** @protected */
         ready() {
           super.ready();
 
@@ -330,6 +344,10 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
 
+        /**
+         * @param {!Array<!Node>} nodes
+         * @protected
+         */
         _setTemplateFromNodes(nodes) {
           this._notificationTemplate = nodes.filter(node => node.localName && node.localName === 'template')[0] || this._notificationTemplate;
         }
@@ -344,6 +362,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.renderer(this._card, this);
         }
 
+        /** @private */
         _removeNewRendererOrTemplate(template, oldTemplate, renderer, oldRenderer) {
           if (template !== oldTemplate) {
             this._notificationTemplate = undefined;
@@ -352,6 +371,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _templateOrRendererChanged(template, renderer, opened) {
           if (template && renderer) {
             this._removeNewRendererOrTemplate(template, this._oldTemplate, renderer, this._oldRenderer);
@@ -395,6 +415,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.opened = false;
         }
 
+        /** @private */
         get _container() {
           if (!NotificationElement._container) {
             NotificationElement._container = document.createElement('vaadin-notification-container');
@@ -403,6 +424,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return NotificationElement._container;
         }
 
+        /** @private */
         _openedChanged(opened) {
           if (opened) {
             this._container.opened = true;
@@ -417,6 +439,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _ensureTemplatized() {
           this._notificationTemplate = this.querySelector('template') || this._notificationTemplate;
 
@@ -476,6 +499,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._card.setAttribute('aria-label', this._card.textContent.trim());
         }
 
+        /** @private */
         _animatedAppendNotificationCard() {
           if (this._card) {
             this._card.setAttribute('opening', '');
@@ -491,6 +515,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _appendNotificationCard() {
           if (!this._card) {
             return;
@@ -510,17 +535,20 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _removeNotificationCard() {
           this._card.parentNode && this._card.parentNode.removeChild(this._card);
           this._card.removeAttribute('closing');
           this._container.opened = Boolean(this._container.firstElementChild);
         }
 
+        /** @private */
         _closeNotificationCard() {
           this._durationTimeoutId && clearTimeout(this._durationTimeoutId);
           this._animatedRemoveNotificationCard();
         }
 
+        /** @private */
         _animatedRemoveNotificationCard() {
           this._card.setAttribute('closing', '');
           const name = getComputedStyle(this._card).getPropertyValue('animation-name');
@@ -535,12 +563,14 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _positionChanged(position) {
           if (this.opened) {
             this._animatedAppendNotificationCard();
           }
         }
 
+        /** @private */
         _durationChanged(duration, opened) {
           if (opened) {
             clearTimeout(this._durationTimeoutId);
@@ -550,6 +580,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _updateShadyButtonStyles() {
           // ShadyCSS doesn't propagate CSS properties to slotted children,
           // so this is done manually to allow vaadin-buttons to be themed
@@ -581,6 +612,8 @@ This program is available under Apache License Version 2.0, available at https:/
       /**
        * @namespace Vaadin
        */
+      window.Vaadin.NotificationContainer = NotificationContainer;
+      window.Vaadin.NotificationCard = NotificationCard;
       window.Vaadin.NotificationElement = NotificationElement;
     })();
   </script>

--- a/src/vaadin-notification.html
+++ b/src/vaadin-notification.html
@@ -612,8 +612,6 @@ This program is available under Apache License Version 2.0, available at https:/
       /**
        * @namespace Vaadin
        */
-      window.Vaadin.NotificationContainer = NotificationContainer;
-      window.Vaadin.NotificationCard = NotificationCard;
       window.Vaadin.NotificationElement = NotificationElement;
     })();
   </script>


### PR DESCRIPTION
Fixes #109 

The generated TS definitions look like this:
```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {templatize} from '@polymer/polymer/lib/utils/templatize.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ThemePropertyMixin} from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';

import {FlattenedNodesObserver} from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class NotificationContainer extends
  ElementMixin(
  ThemableMixin(
  PolymerElement)) {

  opened: boolean;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-notification-container": NotificationContainer;
    "vaadin-notification-card": NotificationCard;
    "vaadin-notification": NotificationElement;
  }
}

declare class NotificationCard extends
  ThemableMixin(
  PolymerElement) {

  ready(): void;
}

declare class NotificationElement extends
  ThemePropertyMixin(
  ElementMixin(
  PolymerElement)) {

  duration: number;
  opened: boolean;
  position: NotificationPosition;
  renderer: NotificationRenderer|undefined;
  _notificationTemplate: HTMLTemplateElement|undefined;

  ready(): void;
  _setTemplateFromNodes(nodes: Node[]): void;
  render(): void;
  open(): void;
  close(): void;
}

export {NotificationContainer};

export {NotificationCard};

export {NotificationElement};

import {NotificationPosition} from '../@types/interfaces';

import {NotificationRenderer} from '../@types/interfaces';

```