### PR TITLE
Remove fixed width from middle position

### DIFF
--- a/theme/lumo/vaadin-notification-styles.js
+++ b/theme/lumo/vaadin-notification-styles.js
@@ -40,7 +40,6 @@ registerStyles(
     }
 
     :host([slot^='middle']) {
-      width: 20em;
       max-width: 80vw;
       margin: var(--lumo-space-s) auto;
     }


### PR DESCRIPTION
I think the fixed width was added to restrict notifications in the middle position from getting too wide. But at the same time adds an unnecessary restriction to the layout, that even reasonable length texts end up wrapping on two lines. 

I think wrapping would be best left to the content itself. 