### PR TITLE
fix: prevent closing overlays when interacting with notifications

### DIFF
--- a/src/vaadin-notification.html
+++ b/src/vaadin-notification.html
@@ -145,12 +145,14 @@ This program is available under Apache License Version 2.0, available at https:/
         _openedChanged(opened) {
           if (opened) {
             document.body.appendChild(this);
+            document.addEventListener('vaadin-overlay-close', this._boundVaadinOverlayClose);
             if (this._boundIosResizeListener) {
               this._detectIosNavbar();
               window.addEventListener('resize', this._boundIosResizeListener);
             }
           } else {
             document.body.removeChild(this);
+            document.removeEventListener('vaadin-overlay-close', this._boundVaadinOverlayClose);
             if (this._boundIosResizeListener) {
               window.removeEventListener('resize', this._boundIosResizeListener);
             }
@@ -160,6 +162,7 @@ This program is available under Apache License Version 2.0, available at https:/
         constructor() {
           super();
 
+          this._boundVaadinOverlayClose = this._onVaadinOverlayClose.bind(this);
           if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
             this._boundIosResizeListener = () => this._detectIosNavbar();
           }
@@ -175,6 +178,17 @@ This program is available under Apache License Version 2.0, available at https:/
             this.style.bottom = (clientHeight - innerHeight) + 'px';
           } else {
             this.style.bottom = '0';
+          }
+        }
+
+        /** @private */
+        _onVaadinOverlayClose(event) {
+          // Notifications are a separate overlay mechanism from vaadin-overlay, and
+          // interacting with them should not close modal overlays
+          const sourceEvent = event.detail.sourceEvent;
+          const isFromNotification = sourceEvent && sourceEvent.composedPath().indexOf(this) >= 0;
+          if (isFromNotification) {
+            event.preventDefault();
           }
         }
       }

--- a/test/vaadin-notification-test.html
+++ b/test/vaadin-notification-test.html
@@ -21,6 +21,14 @@
   </test-fixture>
 
   <script>
+    function listenOnce(element, eventName, callback) {
+      const listener = e => {
+        element.removeEventListener(eventName, listener);
+        callback(e);
+      };
+      element.addEventListener(eventName, listener);
+    }
+
     describe('vaadin-notification', function() {
       var notification;
 
@@ -62,6 +70,34 @@
         it('should be visible after opening', () => {
           var isVisible = (elem) => !!(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length);
           expect(isVisible(document.body.querySelector('vaadin-notification-container'))).to.be.true;
+        });
+
+        it('should cancel vaadin-overlay-close events when the source event occurred within the container', (done) => {
+          listenOnce(document, 'click', (clickEvent) => {
+            const overlayCloseEvent = new CustomEvent('vaadin-overlay-close', {
+              cancelable: true,
+              detail: {sourceEvent: clickEvent}
+            });
+            document.dispatchEvent(overlayCloseEvent);
+
+            expect(overlayCloseEvent.defaultPrevented).to.be.true;
+            done();
+          });
+          notification._card.click();
+        });
+
+        it('should not cancel vaadin-overlay-close events when the source event occurred outside of the container', (done) => {
+          listenOnce(document, 'click', (clickEvent) => {
+            const overlayCloseEvent = new CustomEvent('vaadin-overlay-close', {
+              cancelable: true,
+              detail: {sourceEvent: clickEvent}
+            });
+            document.dispatchEvent(overlayCloseEvent);
+
+            expect(overlayCloseEvent.defaultPrevented).to.be.false;
+            done();
+          });
+          document.body.click();
         });
 
         if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {


### PR DESCRIPTION
cherry-pick of: https://github.com/vaadin/web-components/pull/3208
fixes: https://github.com/vaadin/flow-components/issues/2184
